### PR TITLE
Don't call 'destroy' on validations during teardown, to a fix a use-after-destroy error

### DIFF
--- a/addon/validations/factory.js
+++ b/addon/validations/factory.js
@@ -131,7 +131,7 @@ export default function buildValidations(validations = {}, globalOptions = {}) {
       return get(this, 'validations').validateAttribute(...arguments);
     },
 
-    destroy() {
+    willDestroy() {
       this._super(...arguments);
       get(this, 'validations').destroy();
     }
@@ -260,7 +260,7 @@ function createValidationsClass(inheritedValidationsClass, validations, model) {
       });
     },
 
-    destroy() {
+    willDestroy() {
       this._super(...arguments);
       let validatableAttrs = get(this, 'validatableAttributes');
       let debouncedValidations = get(this, '_debouncedValidations');

--- a/addon/validations/factory.js
+++ b/addon/validations/factory.js
@@ -129,11 +129,6 @@ export default function buildValidations(validations = {}, globalOptions = {}) {
 
     validateAttribute() {
       return get(this, 'validations').validateAttribute(...arguments);
-    },
-
-    willDestroy() {
-      this._super(...arguments);
-      get(this, 'validations').destroy();
     }
   });
 }


### PR DESCRIPTION
Remove the `destroy` method added to objects that mix in validations, since its explicit `get(this, 'validations').destroy()` is causing "Can not call `.factoryFor` after the owner has been destroyed" errors with Ember 3.20.